### PR TITLE
Fix Dockerfile build with the current upstream location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM docker.io/golang:1.15@sha256:c161abf0cde3969e05f6914a86cab804b2b0df515f4ff9570475b25547ba7959 as builder
+FROM docker.io/golang:1.22 as builder
 
 COPY . /opt
 WORKDIR /opt
 
-RUN CGO_ENABLED=0 go build -o /opt/bin/app github.com/certusone/near_exporter/cmd/near_exporter
+RUN env CGO_ENABLED=0 go build -o /opt/bin/near_exporter ./near_exporter/cmd/near_exporter
 
 FROM scratch
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /opt/bin/app /
+COPY --from=builder /opt/bin/near_exporter /
 
-CMD ["/app"]
+CMD ["/near_exporter"]

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Docker images are available on [Docker Hub](https://hub.docker.com/r/certusone/n
 
 Go >= 1.14 is required to build the binary.
 
-### How to build
+### How to install
 
 ```
-go build github.com/certusone/near_exporter/cmd/near_exporter
+env GOBIN=/usr/local/bin go install github.com/ChorusOne/near_exporter/cmd/near_exporter@master
 ```
 
 ### systemd service example
@@ -18,7 +18,7 @@ cp near_exporter /usr/local/bin
 cat <<EOF > /etc/systemd/system/near-exporter.service
 [Unit]
 Description=Certus One near_exporter
-Documentation=https://github.com/certusone/near_exporter
+Documentation=https://github.com/ChorusOne/near_exporter
 After=network.target
 
 [Service]
@@ -35,7 +35,7 @@ EOF
 Enable and start the service:
 
 ```
-systemctl enable --now near-exporter
+systemctl enable --now near-exporter.service
 ```
 
 Exporter will be available at http://localhost:8080/metrics

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,17 @@
-module github.com/certusone/near_exporter
+module github.com/ChorusOne/near_exporter
 
-go 1.14
+go 1.22
 
 require github.com/prometheus/client_golang v1.7.1
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.10.0 // indirect
+	github.com/prometheus/procfs v0.1.3 // indirect
+	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 // indirect
+	google.golang.org/protobuf v1.23.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -85,6 +86,7 @@ golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=


### PR DESCRIPTION
- Update location of near_exporter on GitHub
- Bump Golang to 1.22, but don't pin the image version firmly
- go mod tidy